### PR TITLE
Give vehicle count passed on CLI precedence.

### DIFF
--- a/baselines/hgs_vrptw/Params.cpp
+++ b/baselines/hgs_vrptw/Params.cpp
@@ -152,7 +152,15 @@ Params::Params(const CommandLine& cl)
 				}
 				else if (content == "VEHICLES" || content == "SALESMAN")
 				{
-					inputFile >> content2 >> nbVehicles;
+                    // Set vehicle count from instance only if not specified on CLI.
+                    inputFile >> content2;
+                    if(nbVehicles == INT_MAX) {
+                        inputFile >> nbVehicles;
+                    } else {
+                        // Discard vehicle count
+                        int _;
+                        inputFile >> _;
+                    }
 				}
 				else if (content == "DISTANCE")
 				{


### PR DESCRIPTION
Perfer the CLI vehicle count if set by both the instance and the
commandline.