### PR TITLE
Fix value range for random exploration

### DIFF
--- a/baselines/dqn/agent.py
+++ b/baselines/dqn/agent.py
@@ -106,7 +106,7 @@ class DQNAgent:
 
         # epsilon greedy policy
         if self.dqn.training and self.epsilon > self.rng.random():
-            selected_action = self.rng.integers(0, 2 - 1)
+            selected_action = self.rng.integers(0, 2)
         else:
             selected_action = self.dqn(
                 torch.FloatTensor(state).to(self.device),


### PR DESCRIPTION
As the random range is already exclusive, setting the upper bound to 2-1=1 results in always selecting 0 when doing random exploration which is probably not the intended behavior.